### PR TITLE
Add emission cost plotting option

### DIFF
--- a/cacoca/output/plot_stacked_bars.py
+++ b/cacoca/output/plot_stacked_bars.py
@@ -44,7 +44,7 @@ def plot_stacked_bars(projects: pd.DataFrame, config: dict, project_name: str,
     query_str = " | ".join(f"Period == {y}" for y in years)
     projects = projects.query(query_str).drop_duplicates()
 
-    # 
+    # Hack: Bring Effective CO2 Price in form to be added to reference, divided by emissions diff
     if emission_diff:
         # Emission cost: difference only plotted for reference
         projects = projects.assign(**{
@@ -178,3 +178,4 @@ def plot_stacked_bars(projects: pd.DataFrame, config: dict, project_name: str,
                       title=f"Kostenvergleich {dn(project_name)}")
     fig.update_layout(barmode="relative")
     show_and_save(fig, config, 'stacked_bars_' + project_name)
+    

--- a/plot_slides_polymers.py
+++ b/plot_slides_polymers.py
@@ -74,7 +74,7 @@ project_names = [
     'Gasifizierung-FT']
 for project_name in project_names:
     plot_stacked_bars(cost_and_em_actual, setup.config, project_name=project_name,
-                      cost_per='product')
+                      cost_per='product', emission_diff=False)
     #plot_stacked_bars(cost_and_em_actual, config, project_name=project_name,
     #                   cost_per='em_savings', is_diff=True)
 


### PR DESCRIPTION
Now, if `emission_diff = False`, the emission costs are not only shown in the reference based on the emission difference, but are plotted separately for project and reference.